### PR TITLE
fix: ensure images are responsive with max-width constraint

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -103,4 +103,8 @@ p {
     border-left: 3px solid #ddd;
     padding-left: 1em;
   }
+
+  img {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
close #329 

描述：增加预览图片最大宽度限制

![img](https://raw.githubusercontent.com/Fog3211/reproduce-codesandbox/refs/heads/main/assets/images/20241105-174553.jpeg)